### PR TITLE
feat: ソート機能を追加した

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -27,7 +27,7 @@
     }
   },
   "lint-staged": {
-    "*": "deno lint && deno fmt & deno test"
+    "*": "deno lint && deno fmt & deno run test"
   },
   "fmt": {
     "useTabs": false,
@@ -46,9 +46,10 @@
   "tasks": {
     "init": "deno task git-config && deno task setup-hooks && deno task build",
     "start": "deno run --allow-net --allow-read --watch src/server.ts",
-    "build": "deno fmt && deno task cached && deno test",
+    "build": "deno fmt && deno task cached && deno run test",
+    "test": "deno test --allow-read --allow-net=raw.githubusercontent.com:443",
     "cached": "sh .shell/cached.sh",
-    "ci": "deno lint && deno fmt --check && deno test",
+    "ci": "deno lint && deno fmt --check && deno run test",
     // git hooks
     "setup-hooks": "deno run --allow-read --allow-run https://pax.deno.dev/kawarimidoll/deno-dev-template/scripts/setup-hooks.ts",
     "pre-commit": "deno run --allow-read --allow-env --allow-run --allow-write https://pax.deno.dev/kawarimidoll/deno-dev-template/scripts/lint-staged.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -106,9 +106,6 @@
       "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     }
   },
-  "remote": {
-    "https://raw.githubusercontent.com/hytsnbr/shiny-colors-cd-info-collector/main/result/data.json": "368b8e223923c9f971dd6749a7bc15383bef8f2585c1747f1df4216ca9dcf10a"
-  },
   "workspace": {
     "dependencies": [
       "jsr:@oak/oak@17.1.3",

--- a/src/controllers/api_controller.ts
+++ b/src/controllers/api_controller.ts
@@ -2,6 +2,7 @@ import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
 import { Response } from "@/model/response.ts";
 import { RouterContext } from "@oak/oak";
+import { Logger } from "@/logger.ts";
 import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 
 export const apiController = {
@@ -17,6 +18,20 @@ export const apiController = {
     const series = searchParams.get("series") || "";
     const storeName = searchParams.get("storeName") || "";
     const isHiRes = searchParams.get("isHiRes") || "";
+    const sort = searchParams.get("sort") || "";
+
+    Logger.debug(`Debug Query Parameters:`);
+    Logger.debug(` releaseDateStart: ${releaseDateStart}`);
+    Logger.debug(` releaseDateEnd: ${releaseDateEnd}`);
+    Logger.debug(` recordNumber: ${recordNumber}`);
+    Logger.debug(` recordNumbers: ${recordNumbers}`);
+    Logger.debug(` limited: ${limited}`);
+    Logger.debug(` title: ${title}`);
+    Logger.debug(` artist: ${artist}`);
+    Logger.debug(` series: ${series}`);
+    Logger.debug(` storeName: ${storeName}`);
+    Logger.debug(` isHiRes: ${isHiRes}`);
+    Logger.debug(` sort: ${sort}`);
 
     const cdInfoList: CdInfoList = await getCdInfoListFromGithub();
     const result: CdInfo[] = cdInfoList
@@ -29,6 +44,7 @@ export const apiController = {
       .filterByLimited(limited)
       .filterByStoreName(storeName)
       .filterByHiResStore(isHiRes)
+      .sort(sort)
       .getList();
 
     ctx.response.body = new Response(result).list;

--- a/src/controllers/api_controller.ts
+++ b/src/controllers/api_controller.ts
@@ -1,11 +1,11 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
 import { Response } from "@/model/response.ts";
 import { RouterContext } from "@oak/oak";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 
 export const apiController = {
-  getList(ctx: RouterContext<string>): void {
+  async getList(ctx: RouterContext<string>): Promise<void> {
     const searchParams = ctx.request.url.searchParams;
     const releaseDateStart = searchParams.get("releaseDateStart") || "";
     const releaseDateEnd = searchParams.get("releaseDateEnd") || "";
@@ -18,7 +18,7 @@ export const apiController = {
     const storeName = searchParams.get("storeName") || "";
     const isHiRes = searchParams.get("isHiRes") || "";
 
-    const cdInfoList: CdInfoList = dataJsonConvertor();
+    const cdInfoList: CdInfoList = await getCdInfoListFromGithub();
     const result: CdInfo[] = cdInfoList
       .filterByTitle(title)
       .filterByArtist(artist)

--- a/src/functions/data_json_convertor.ts
+++ b/src/functions/data_json_convertor.ts
@@ -1,28 +1,80 @@
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
-import dataJson from "https://raw.githubusercontent.com/hytsnbr/shiny-colors-cd-info-collector/main/result/data.json" with {
-  type: "json",
-};
+import { Logger } from "@/logger.ts";
 
-export default (): CdInfoList => {
-  const jsonData = dataJson;
+/**
+ * 指定のJSONファイルから情報を取得する
+ * @param url データ取得先JSONファイルURL
+ * @returns CD情報リスト
+ */
+export async function getCdInfoListCustomJson(
+  url: string,
+): Promise<CdInfoList> {
+  return await getCdInfoList(url);
+}
 
+/**
+ * Github上のJSONファイルから情報を取得する
+ * @returns CD情報リスト
+ */
+export async function getCdInfoListFromGithub(): Promise<CdInfoList> {
+  return await getCdInfoList(
+    "https://raw.githubusercontent.com/hytsnbr/shiny-colors-cd-info-collector/main/result/data.json",
+  );
+}
+
+/**
+ * 指定されたJSONファイルからデータを取得する
+ * @param url データ取得先JSONファイルURL
+ * @returns CD情報リスト
+ */
+async function getCdInfoArrayData(url: string): Promise<CdInfo[]> {
+  const response = await fetch(url)
+    .then((response: Response) => {
+      Logger.info(`Fetch URL: ${url}`);
+      if (response.ok === false) {
+        throw new Error("Fetch Error");
+      }
+      Logger.info(
+        `Response Status: ${response.statusText}(${response.status})`,
+      );
+
+      return response;
+    }).catch((error: Error) => {
+      Logger.error(error.message);
+
+      throw error;
+    });
+  const jsonData = await response.json();
+
+  return jsonData.info;
+}
+
+/**
+ * {@linkcode CdInfoList}を新規作成する
+ * @param url データ取得先JSONファイルURL
+ * @returns CdInfoList
+ */
+async function getCdInfoList(url: string): Promise<CdInfoList> {
   const resultList: CdInfo[] = [];
-  Array.from(jsonData.info).forEach((info) => {
-    resultList.push(
-      new CdInfo(
-        info.title !== null ? info.title : "",
-        info.recordNumbers !== null ? info.recordNumbers : [],
-        info.releaseDate !== null ? new Date(info.releaseDate) : null,
-        info.jacketUrl !== null ? info.jacketUrl : "",
-        info.limited,
-        info.series !== null ? info.series : "",
-        info.artist !== null ? info.artist : "",
-        info.downloadSiteList !== null ? info.downloadSiteList : [],
-        info.purchaseSiteList !== null ? info.purchaseSiteList : [],
-      ),
-    );
-  });
+  await getCdInfoArrayData(url)
+    .then((cdInfoArray: CdInfo[]) => {
+      cdInfoArray.forEach((info: CdInfo) => {
+        resultList.push(
+          new CdInfo(
+            info.title !== null ? info.title : "",
+            info.recordNumbers !== null ? info.recordNumbers : [],
+            info.releaseDate !== null ? new Date(info.releaseDate) : null,
+            info.jacketUrl !== null ? info.jacketUrl : "",
+            info.limited,
+            info.series !== null ? info.series : "",
+            info.artist !== null ? info.artist : "",
+            info.downloadSiteList !== null ? info.downloadSiteList : [],
+            info.purchaseSiteList !== null ? info.purchaseSiteList : [],
+          ),
+        );
+      });
+    });
 
   return new CdInfoList(resultList);
-};
+}

--- a/src/model/cd_info_list.ts
+++ b/src/model/cd_info_list.ts
@@ -2,6 +2,7 @@ import { hasDuplicateValue } from "@/functions/array_util.ts";
 import { isValidDate } from "@/functions/date_util.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { Store } from "@/model/store.ts";
+import { Logger } from "@/logger.ts";
 
 export class CdInfoList {
   private list: CdInfo[];
@@ -192,6 +193,121 @@ export class CdInfoList {
 
       return cdInfo;
     });
+
+    return this;
+  }
+
+  sort(sort: string): CdInfoList {
+    if (sort === "") {
+      return this;
+    }
+
+    const sortRegex = "(.+):(asc|desc)";
+    const sortOrders = sort.replaceAll(" ", "").split(",");
+
+    for (const sortOrder of sortOrders) {
+      const keyName = sortOrder.match(sortRegex)?.at(1) || "";
+      const orderby = sortOrder.match(sortRegex)?.at(2) || "";
+
+      switch (orderby) {
+        case "asc":
+          this.sortAsc(keyName);
+          break;
+        case "desc":
+          this.sortDesc(keyName);
+          break;
+        default:
+          Logger.error(`Invalid sort order: ${sortOrder}`);
+
+          throw new Error(`Invalid sort order: ${sortOrder}`);
+      }
+    }
+
+    return this;
+  }
+
+  private sortAsc(sortKeyName: string): CdInfoList {
+    if (sortKeyName === "") {
+      return this;
+    }
+
+    switch (sortKeyName) {
+      case "title":
+        this.list.sort((x, y) => {
+          const xTitle = x.title.replaceAll(/[“”]/g, "");
+          const yTitle = y.title.replaceAll(/[“”]/g, "");
+
+          return xTitle.localeCompare(yTitle);
+        });
+        break;
+      case "recordNumbers":
+        this.list.sort((x, y) =>
+          x.recordNumbers[0] > y.recordNumbers[0] ? 1 : -1
+        );
+        break;
+      case "releaseDate":
+        this.list.sort((x, y) => {
+          if (x.releaseDate === null) {
+            return -1;
+          }
+          if (y.releaseDate === null) {
+            return 1;
+          }
+          return x.releaseDate > y.releaseDate ? 1 : -1;
+        });
+        break;
+      case "artist":
+        this.list.sort((x, y) => {
+          const xArtist = x.artist;
+          const yArtist = y.artist;
+
+          return xArtist.localeCompare(yArtist);
+        });
+        break;
+    }
+
+    return this;
+  }
+
+  private sortDesc(sortKeyName: string): CdInfoList {
+    if (sortKeyName === "") {
+      return this;
+    }
+
+    switch (sortKeyName) {
+      case "title":
+        this.list.sort((x, y) => {
+          const xTitle = x.title.replaceAll(/[“”]/g, "");
+          const yTitle = y.title.replaceAll(/[“”]/g, "");
+
+          return xTitle.localeCompare(yTitle) * -1; // 降順なので正負を反転させる
+        });
+        break;
+      case "recordNumbers":
+        this.list.sort((x, y) =>
+          x.recordNumbers[0] < y.recordNumbers[0] ? 1 : -1
+        );
+        break;
+      case "releaseDate":
+        this.list.sort((x, y) => {
+          if (x.releaseDate === null) {
+            return 1;
+          }
+          if (y.releaseDate === null) {
+            return -1;
+          }
+          return x.releaseDate < y.releaseDate ? 1 : -1;
+        });
+        break;
+      case "artist":
+        this.list.sort((x, y) => {
+          const xArtist = x.artist;
+          const yArtist = y.artist;
+
+          return xArtist.localeCompare(yArtist) * -1; // 降順なので正負を反転させる
+        });
+        break;
+    }
 
     return this;
   }

--- a/src/tests/model/artist_test.ts
+++ b/src/tests/model/artist_test.ts
@@ -1,19 +1,20 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
 import { assertEquals, assertFalse, assertMatch } from "@std/assert";
 
-Deno.test("アーティスト名検索テスト：1件だけヒット", () => {
+Deno.test("アーティスト名検索テスト：1件だけヒット", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const artist = "斑鳩ルカ";
   const expectedCount = 1;
   const expectedArtist = RegExp(`.*${artist}.*`);
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByArtist(artist).getList();
-
-  const actualCount = result.length;
-  const actualArtist = result[0].artist;
+  const filteringResult: CdInfo[] = source.filterByArtist(artist)
+    .getList();
+  const actualCount = filteringResult.length;
+  const actualArtist = filteringResult[0].artist;
 
   Logger.info(`検索アーティスト名：${artist}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -25,17 +26,18 @@ Deno.test("アーティスト名検索テスト：1件だけヒット", () => {
   assertMatch(actualArtist, expectedArtist);
 });
 
-Deno.test("アーティスト名検索テスト：複数件数ヒット", () => {
+Deno.test("アーティスト名検索テスト：複数件数ヒット", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const artist = "ストレイライト";
   const regexpArtist = RegExp(`.*${artist}.*`);
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByArtist(artist).getList();
-
+  const filteringResult: CdInfo[] = source.filterByArtist(artist)
+    .getList();
   Logger.info(`検索アーティスト名：${artist}`);
 
   let isContainNotMatchArtist = false;
-  result.forEach((cdInfo) => {
+  filteringResult.forEach((cdInfo) => {
     Logger.info(
       `アーティスト名：${cdInfo.artist} / CDタイトル名：${cdInfo.title}`,
     );
@@ -47,14 +49,15 @@ Deno.test("アーティスト名検索テスト：複数件数ヒット", () => 
   assertFalse(isContainNotMatchArtist);
 });
 
-Deno.test("アーティスト名検索テスト：ヒットなし", () => {
+Deno.test("アーティスト名検索テスト：ヒットなし", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const artist = "櫻木真乃";
   const expected = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByArtist(artist).getList();
-
-  const actual = result.length;
+  const filteringResult: CdInfo[] = source.filterByArtist(artist)
+    .getList();
+  const actual = filteringResult.length;
 
   Logger.info(`検索アーティスト名：${artist}`);
   Logger.info(`ヒット件数：${actual} / 期待値：${expected}`);

--- a/src/tests/model/is_hires_test.ts
+++ b/src/tests/model/is_hires_test.ts
@@ -1,4 +1,4 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
@@ -9,19 +9,18 @@ import {
   assertLess,
 } from "@std/assert";
 
-const cdInfoList: CdInfoList = dataJsonConvertor();
-const cdInfo: CdInfo = cdInfoList.getList()[0];
-const maxDownloadSiteCount: number = cdInfo.downloadSiteList.length;
+Deno.test("ハイレゾ対応ストア検索テスト：ハイレゾ対応のみ", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+  const cdInfoAtFirst: CdInfo = source.getList()[0];
+  const maxDownloadSiteCount: number = cdInfoAtFirst.downloadSiteList.length;
 
-Deno.test("ハイレゾ対応ストア検索テスト：ハイレゾ対応のみ", () => {
   const isHiRes = "true";
   const exceptedMin = 0;
   const exceptedMax = maxDownloadSiteCount;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo = cdInfoList.filterByHiResStore(isHiRes).getList()[0];
-
-  const actual = result.downloadSiteList.length;
+  const filteringResult: CdInfo =
+    source.filterByHiResStore(isHiRes).getList()[0];
+  const actual = filteringResult.downloadSiteList.length;
 
   Logger.info(`件数：${actual} / 期待値：${exceptedMin} < X < ${exceptedMax}`);
 
@@ -29,7 +28,7 @@ Deno.test("ハイレゾ対応ストア検索テスト：ハイレゾ対応のみ
   assertLess(actual, exceptedMax);
 
   let isContainNotHiRes = false;
-  result.downloadSiteList.forEach((downloadSite) => {
+  filteringResult.downloadSiteList.forEach((downloadSite) => {
     Logger.info(
       `サイト名：${downloadSite.name} / ハイレゾ対応：${downloadSite.isHiRes}`,
     );
@@ -41,14 +40,17 @@ Deno.test("ハイレゾ対応ストア検索テスト：ハイレゾ対応のみ
   assertFalse(isContainNotHiRes);
 });
 
-Deno.test("ハイレゾ対応ストア検索テスト：すべて", () => {
+Deno.test("ハイレゾ対応ストア検索テスト：すべて", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+  const cdInfoAtFirst: CdInfo = source.getList()[0];
+  const maxDownloadSiteCount: number = cdInfoAtFirst.downloadSiteList.length;
+
   const isHiRes = "false";
   const excepted = maxDownloadSiteCount;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo = cdInfoList.filterByHiResStore(isHiRes).getList()[0];
-
-  const actual = result.downloadSiteList.length;
+  const filteringResult: CdInfo =
+    source.filterByHiResStore(isHiRes).getList()[0];
+  const actual = filteringResult.downloadSiteList.length;
 
   Logger.info(`件数：${actual} / 期待値：${excepted}`);
 

--- a/src/tests/model/limited_test.ts
+++ b/src/tests/model/limited_test.ts
@@ -1,4 +1,4 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
@@ -9,19 +9,17 @@ import {
   assertLess,
 } from "@std/assert";
 
-const cdInfoList: CdInfoList = dataJsonConvertor();
-const cdInfos: CdInfo[] = cdInfoList.getList();
-const maxCdCount: number = cdInfos.length;
+Deno.test("限定販売検索テスト：限定販売のみ", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+  const cdInfoAll: CdInfo[] = source.getList();
+  const maxCdCount: number = cdInfoAll.length;
 
-Deno.test("限定販売検索テスト：限定販売のみ", () => {
   const limited = "true";
   const exceptedMin = 0;
   const exceptedMax = maxCdCount;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByLimited(limited).getList();
-
-  const actual = result.length;
+  const filteringResult: CdInfo[] = source.filterByLimited(limited).getList();
+  const actual = filteringResult.length;
 
   Logger.info(`件数：${actual} / 期待値：${exceptedMin} < X < ${exceptedMax}`);
 
@@ -29,7 +27,7 @@ Deno.test("限定販売検索テスト：限定販売のみ", () => {
   assertLess(actual, exceptedMax);
 
   let isContainNotLimited = false;
-  result.forEach((cdInfo) => {
+  filteringResult.forEach((cdInfo) => {
     Logger.info(
       `CDタイトル名：${cdInfo.title} / 限定販売：${cdInfo.limited}`,
     );
@@ -41,14 +39,16 @@ Deno.test("限定販売検索テスト：限定販売のみ", () => {
   assertFalse(isContainNotLimited);
 });
 
-Deno.test("限定販売検索テスト：すべて", () => {
+Deno.test("限定販売検索テスト：すべて", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+  const cdInfoAll: CdInfo[] = source.getList();
+  const maxCdCount: number = cdInfoAll.length;
+
   const limited = "false";
   const excepted = maxCdCount;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByLimited(limited).getList();
-
-  const actual = result.length;
+  const filteringResult: CdInfo[] = source.filterByLimited(limited).getList();
+  const actual = filteringResult.length;
 
   Logger.info(`件数：${actual} / 期待値：${excepted}`);
 

--- a/src/tests/model/record_number_test.ts
+++ b/src/tests/model/record_number_test.ts
@@ -1,20 +1,20 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
 import { assertEquals } from "@std/assert";
 
-Deno.test("品番検索テスト：ヒットあり（1つだけ指定）", () => {
+Deno.test("品番検索テスト：ヒットあり（1つだけ指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const recordNumber = "LACM-24395";
   const expectedRecordNumber = recordNumber;
   const expectedTitle = "THE IDOLM@STER SHINY COLORS COLORFUL FE@THERS -SHHis-";
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByRecordNumber(recordNumber)
+  const filteringResult: CdInfo[] = source.filterByRecordNumber(recordNumber)
     .getList();
-
-  const actualRecordNumber = result[0].recordNumbers[0];
-  const actualTitle = result[0].title;
+  const actualRecordNumber = filteringResult[0].recordNumbers[0];
+  const actualTitle = filteringResult[0].title;
 
   Logger.info(`検索品番：${recordNumber}`);
   Logger.info(
@@ -26,15 +26,15 @@ Deno.test("品番検索テスト：ヒットあり（1つだけ指定）", () =>
   assertEquals(actualTitle, expectedTitle);
 });
 
-Deno.test("品番検索テスト：ヒットなし（1つだけ指定）", () => {
+Deno.test("品番検索テスト：ヒットなし（1つだけ指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const recordNumber = "LACM-12345";
   const expected = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByRecordNumber(recordNumber)
+  const filteringResult: CdInfo[] = source.filterByRecordNumber(recordNumber)
     .getList();
-
-  const actual = result.length;
+  const actual = filteringResult.length;
 
   Logger.info(`検索品番：${recordNumber}`);
   Logger.info(`ヒット件数：${actual} / 期待値：${expected}`);

--- a/src/tests/model/record_numbers_test.ts
+++ b/src/tests/model/record_numbers_test.ts
@@ -1,10 +1,12 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
 import { assertEquals, assertFalse } from "@std/assert";
 
-Deno.test("品番検索テスト：ヒットあり（複数指定、存在する品番のみ）", () => {
+Deno.test("品番検索テスト：ヒットあり（複数指定、存在する品番のみ）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const recordNumbers =
     "LACM-24361, LACM-24362, LACM-24363, LACM-24364, LACM-24365, LACM-24366, LACM-24367, LACM-24368";
   const expectedCount = 8;
@@ -43,11 +45,9 @@ Deno.test("品番検索テスト：ヒットあり（複数指定、存在する
     },
   ];
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByRecordNumbers(recordNumbers)
+  const filteringResult: CdInfo[] = source.filterByRecordNumbers(recordNumbers)
     .getList();
-
-  const actualCount = result.length;
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索品番：${recordNumbers}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -55,7 +55,7 @@ Deno.test("品番検索テスト：ヒットあり（複数指定、存在する
   assertEquals(actualCount, expectedCount);
 
   let isContainNotMatchRecordNumber = false;
-  result.forEach((cdInfo) => {
+  filteringResult.forEach((cdInfo) => {
     const expectedData = expectedDataList.find((data) => {
       return data.title === cdInfo.title &&
         cdInfo.recordNumbers.some((recordNumber) =>
@@ -80,7 +80,9 @@ Deno.test("品番検索テスト：ヒットあり（複数指定、存在する
   assertFalse(isContainNotMatchRecordNumber);
 });
 
-Deno.test("品番検索テスト：ヒットあり（複数指定、存在しない品番を含む）", () => {
+Deno.test("品番検索テスト：ヒットあり（複数指定、存在しない品番を含む）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const recordNumbers = "LACM-24437, LACM-12345, LACM-24406";
   const expectedCount = 2;
   const expectedDataList = [
@@ -94,11 +96,9 @@ Deno.test("品番検索テスト：ヒットあり（複数指定、存在しな
     },
   ];
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByRecordNumbers(recordNumbers)
+  const filteringResult: CdInfo[] = source.filterByRecordNumbers(recordNumbers)
     .getList();
-
-  const actualCount = result.length;
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索品番：${recordNumbers}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -106,7 +106,7 @@ Deno.test("品番検索テスト：ヒットあり（複数指定、存在しな
   assertEquals(actualCount, expectedCount);
 
   let isContainNotMatchRecordNumber = false;
-  result.forEach((cdInfo) => {
+  filteringResult.forEach((cdInfo) => {
     const expectedData = expectedDataList.find((data) => {
       return data.title === cdInfo.title &&
         cdInfo.recordNumbers.some((recordNumber) =>
@@ -131,15 +131,15 @@ Deno.test("品番検索テスト：ヒットあり（複数指定、存在しな
   assertFalse(isContainNotMatchRecordNumber);
 });
 
-Deno.test("品番検索テスト：ヒットなし（複数指定）", () => {
+Deno.test("品番検索テスト：ヒットなし（複数指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const recordNumber = "LACM-12345, LACM-67890, LACZ-1215";
   const expected = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByRecordNumber(recordNumber)
+  const filteringResult: CdInfo[] = source.filterByRecordNumber(recordNumber)
     .getList();
-
-  const actual = result.length;
+  const actual = filteringResult.length;
 
   Logger.info(`検索品番：${recordNumber}`);
   Logger.info(`ヒット件数：${actual} / 期待値：${expected}`);

--- a/src/tests/model/release_date_test.ts
+++ b/src/tests/model/release_date_test.ts
@@ -1,4 +1,4 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { formatDate } from "@/functions/date_util.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
@@ -10,18 +10,19 @@ import {
   assertLessOrEqual,
 } from "@std/assert";
 
-Deno.test("リリース日検索テスト：1件だけヒット（1日指定）", () => {
+Deno.test("リリース日検索テスト：1件だけヒット（1日指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const date = "2023-11-8";
   const expectedCount = 1;
   const expectedReleaseDate = new Date(date);
   const expectedTitle = "THE IDOLM@STER SHINY COLORS “CANVAS” 08";
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByReleaseDate(date, date).getList();
-
-  const actualCount = result.length;
-  const actualReleaseDate = result[0].releaseDate;
-  const actualTitle = result[0].title;
+  const filteringResult: CdInfo[] = source.filterByReleaseDate(date, date)
+    .getList();
+  const actualCount = filteringResult.length;
+  const actualReleaseDate = filteringResult[0].releaseDate;
+  const actualTitle = filteringResult[0].title;
 
   Logger.info(`検索リリース日：${date}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -37,20 +38,23 @@ Deno.test("リリース日検索テスト：1件だけヒット（1日指定）"
   assertEquals(actualTitle, expectedTitle);
 });
 
-Deno.test("リリース日検索テスト：1件だけヒット（範囲日指定）", () => {
+Deno.test("リリース日検索テスト：1件だけヒット（範囲日指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const startDate = "2023-08-01";
   const endDate = "2023-09-01";
   const expectedCount = 1;
   const expectedReleaseDate = new Date("2023-08-09");
   const expectedTitle = "THE IDOLM@STER SHINY COLORS “CANVAS” 05";
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByReleaseDate(startDate, endDate)
+  const filteringResult: CdInfo[] = source.filterByReleaseDate(
+    startDate,
+    endDate,
+  )
     .getList();
-
-  const actualCount = result.length;
-  const actualReleaseDate = result[0].releaseDate;
-  const actualTitle = result[0].title;
+  const actualCount = filteringResult.length;
+  const actualReleaseDate = filteringResult[0].releaseDate;
+  const actualTitle = filteringResult[0].title;
 
   Logger.info(`検索リリース日：${startDate} ～ ${endDate}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -66,7 +70,9 @@ Deno.test("リリース日検索テスト：1件だけヒット（範囲日指�
   assertEquals(actualTitle, expectedTitle);
 });
 
-Deno.test("リリース日検索テスト：複数件数ヒット", () => {
+Deno.test("リリース日検索テスト：複数件数ヒット", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const startDate = "2021-07-01";
   const endDate = "2021-10-01";
   const expectedCount = 4;
@@ -90,11 +96,12 @@ Deno.test("リリース日検索テスト：複数件数ヒット", () => {
     },
   ];
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByReleaseDate(startDate, endDate)
+  const filteringResult: CdInfo[] = source.filterByReleaseDate(
+    startDate,
+    endDate,
+  )
     .getList();
-
-  const actualCount = result.length;
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索リリース日：${startDate} ～ ${endDate}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -102,7 +109,7 @@ Deno.test("リリース日検索テスト：複数件数ヒット", () => {
   assertEquals(actualCount, expectedCount);
 
   let isNotContained = false;
-  result.forEach((cdInfo) => {
+  filteringResult.forEach((cdInfo) => {
     const expectedData = expectedDataList.find((data) => {
       return data.title === cdInfo.title &&
         formatDate(data.releaseDate) === formatDate(cdInfo.releaseDate);
@@ -123,20 +130,24 @@ Deno.test("リリース日検索テスト：複数件数ヒット", () => {
   assertFalse(isNotContained);
 });
 
-Deno.test("リリース日検索テスト：範囲開始日指定", () => {
+Deno.test("リリース日検索テスト：範囲開始日指定", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+  const cdInfoAll: CdInfo[] = source.getList();
+
   const startDate = "2018-11-01";
   const endDate = "";
-  const expectedCount = dataJsonConvertor().getList()
+  const expectedCount = cdInfoAll
     .filter((cdInfo) => cdInfo.releaseDate !== null).length - 5;
 
-  const releaseDateNullCount = dataJsonConvertor().getList()
+  const releaseDateNullCount = cdInfoAll
     .filter((cdInfo) => cdInfo.releaseDate === null).length;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByReleaseDate(startDate, endDate)
+  const filteringResult: CdInfo[] = source.filterByReleaseDate(
+    startDate,
+    endDate,
+  )
     .getList();
-
-  const actualCount = result.length;
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索リリース日：${startDate} ～ ${endDate}`);
   Logger.info(
@@ -147,7 +158,9 @@ Deno.test("リリース日検索テスト：範囲開始日指定", () => {
   assertLessOrEqual(actualCount, expectedCount);
 });
 
-Deno.test("リリース日検索テスト：範囲終了日指定", () => {
+Deno.test("リリース日検索テスト：範囲終了日指定", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const startDate = "";
   const endDate = "2018-10-31";
   const expectedCount = 5;
@@ -178,11 +191,12 @@ Deno.test("リリース日検索テスト：範囲終了日指定", () => {
     },
   ];
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByReleaseDate(startDate, endDate)
+  const filteringResult: CdInfo[] = source.filterByReleaseDate(
+    startDate,
+    endDate,
+  )
     .getList();
-
-  const actualCount = result.length;
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索リリース日：${startDate} ～ ${endDate}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -190,7 +204,7 @@ Deno.test("リリース日検索テスト：範囲終了日指定", () => {
   assertEquals(actualCount, expectedCount);
 
   let isNotContained = false;
-  result.forEach((cdInfo) => {
+  filteringResult.forEach((cdInfo) => {
     const expectedData = expectedDataList.find((data) => {
       return data.title === cdInfo.title &&
         formatDate(data.releaseDate) === formatDate(cdInfo.releaseDate);
@@ -211,14 +225,15 @@ Deno.test("リリース日検索テスト：範囲終了日指定", () => {
   assertFalse(isNotContained);
 });
 
-Deno.test("リリース日検索テスト：ヒットなし（1日指定）", () => {
+Deno.test("リリース日検索テスト：ヒットなし（1日指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const date = "2023-01-01";
   const expectedCount = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByReleaseDate(date, date).getList();
-
-  const actualCount = result.length;
+  const filteringResult: CdInfo[] = source.filterByReleaseDate(date, date)
+    .getList();
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索リリース日：${date}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -226,16 +241,19 @@ Deno.test("リリース日検索テスト：ヒットなし（1日指定）", ()
   assertEquals(actualCount, expectedCount);
 });
 
-Deno.test("リリース日検索テスト：ヒットなし（範囲日指定）", () => {
+Deno.test("リリース日検索テスト：ヒットなし（範囲日指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const startDate = "2019-01-01";
   const endDate = "2019-03-01";
   const expectedCount = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByReleaseDate(startDate, endDate)
+  const filteringResult: CdInfo[] = source.filterByReleaseDate(
+    startDate,
+    endDate,
+  )
     .getList();
-
-  const actualCount = result.length;
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索リリース日：${startDate} ～ ${endDate}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);

--- a/src/tests/model/series_test.ts
+++ b/src/tests/model/series_test.ts
@@ -1,16 +1,17 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
 import { assertEquals, assertFalse } from "@std/assert";
 
-Deno.test("シリーズ名検索テスト：1件だけヒット", () => {
+Deno.test("シリーズ名検索テスト：1件だけヒット", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const series = "SE@SONAL WINTER";
   const expectedCount = 1;
   const expectedSeries = series;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterBySeries(series).getList();
+  const result: CdInfo[] = source.filterBySeries(series).getList();
 
   const actualCount = result.length;
   const actualSeries = result[0].series;
@@ -25,13 +26,14 @@ Deno.test("シリーズ名検索テスト：1件だけヒット", () => {
   assertEquals(actualSeries, expectedSeries);
 });
 
-Deno.test("シリーズ名検索テスト：複数件数ヒット", () => {
+Deno.test("シリーズ名検索テスト：複数件数ヒット", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const series = "GR@DATE WING";
   const expectedCount = 7;
   const expectedSeries = series;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterBySeries(series).getList();
+  const result: CdInfo[] = source.filterBySeries(series).getList();
 
   const actualCount = result.length;
 
@@ -51,12 +53,13 @@ Deno.test("シリーズ名検索テスト：複数件数ヒット", () => {
   assertFalse(isContainNotMatchSeries);
 });
 
-Deno.test("シリーズ名検索テスト：ヒットなし", () => {
+Deno.test("シリーズ名検索テスト：ヒットなし", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const series = "ABCD";
   const expected = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterBySeries(series).getList();
+  const result: CdInfo[] = source.filterBySeries(series).getList();
 
   const actual = result.length;
 

--- a/src/tests/model/sort_test.ts
+++ b/src/tests/model/sort_test.ts
@@ -1,0 +1,228 @@
+import { assertEquals } from "@std/assert/equals";
+import { Logger } from "@/logger.ts";
+import { CdInfoList } from "@/model/cd_info_list.ts";
+import { assertThrows } from "@std/assert/throws";
+import {
+  getCdInfoListCustomJson,
+  getCdInfoListFromGithub,
+} from "@/functions/data_json_convertor.ts";
+
+Deno.test("並び替えテスト：タイトル（昇順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/title_test_source.json"),
+  );
+
+  const sort = "title:asc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl("../resources/sort/title_asc_test_expected.json"),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：タイトル（降順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/title_test_source.json"),
+  );
+
+  const sort = "title:desc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl("../resources/sort/title_desc_test_expected.json"),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：品番（昇順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/recordNumbers_test_source.json"),
+  );
+
+  const sort = "recordNumbers:asc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl(
+        "../resources/sort/recordNumbers_asc_test_expected.json",
+      ),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：品番（降順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/recordNumbers_test_source.json"),
+  );
+
+  const sort = "recordNumbers:desc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl(
+        "../resources/sort/recordNumbers_desc_test_expected.json",
+      ),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：リリース日（昇順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/releaseDate_test_source.json"),
+  );
+
+  const sort = "releaseDate:asc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl(
+        "../resources/sort/releaseDate_asc_test_expected.json",
+      ),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：リリース日（降順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/releaseDate_test_source.json"),
+  );
+
+  const sort = "releaseDate:desc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl(
+        "../resources/sort/releaseDate_desc_test_expected.json",
+      ),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：アーティスト名（昇順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/artist_test_source.json"),
+  );
+
+  const sort = "artist:asc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl(
+        "../resources/sort/artist_asc_test_expected.json",
+      ),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：アーティスト名（降順）", async () => {
+  const source: CdInfoList = await getCdInfoListCustomJson(
+    createLocalJsonUrl("../resources/sort/artist_test_source.json"),
+  );
+
+  const sort = "artist:desc";
+  const expected = JSON.stringify(
+    await getCdInfoListCustomJson(
+      createLocalJsonUrl(
+        "../resources/sort/artist_desc_test_expected.json",
+      ),
+    ).then((cdInfoList: CdInfoList) => cdInfoList.getList()),
+  );
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  Logger.info(`ソート指定：${sort}`);
+  Logger.info(`ソート結果：${actual} / 期待値：${expected}`);
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：不明パラメータ指定（ソート形式指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
+  const sort = "ABCD:asc";
+  const expected = JSON.stringify(source.getList());
+
+  const actual = JSON.stringify(source.sort(sort).getList());
+
+  assertEquals(actual, expected);
+});
+
+Deno.test("並び替えテスト：不明パラメータ指定（ソート形式未指定）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
+  const sort = "ABCD";
+
+  assertThrows(
+    () => {
+      return JSON.stringify(source.sort(sort).getList());
+    },
+    Error,
+    "Invalid sort order",
+  );
+});
+
+Deno.test("並び替えテスト：不明パラメータ指定（カンマだけ）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
+  const sort = ",";
+
+  assertThrows(
+    () => {
+      return JSON.stringify(source.sort(sort).getList());
+    },
+    Error,
+    "Invalid sort order",
+  );
+});
+
+/**
+ * ローカルファイルの相対パスを絶対ファイルURLに変換する
+ * @param relativePath ローカルファイルの相対パス
+ * @returns 変換後の絶対ファイルURL
+ */
+function createLocalJsonUrl(relativePath: string): string {
+  return new URL(relativePath, import.meta.url).toString();
+}

--- a/src/tests/model/store_name_test.ts
+++ b/src/tests/model/store_name_test.ts
@@ -1,4 +1,4 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
@@ -8,17 +8,17 @@ import {
   assertLessOrEqual,
 } from "@std/assert";
 
-const cdInfos: CdInfo[] = dataJsonConvertor().getList();
-const maxCdCount: number = cdInfos.length;
+Deno.test("ストア名検索テスト：ヒットあり（パッケージ版）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+  const cdInfoAll: CdInfo[] = source.getList();
+  const maxCdCount: number = cdInfoAll.length;
 
-Deno.test("ストア名検索テスト：ヒットあり（パッケージ版）", () => {
   const storeName = "TOWER RECORDS ONLINE";
   const exceptedMin = 1;
   const exceptedMax = maxCdCount;
   const regexpStoreName = RegExp(`.*${storeName}.*`);
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByStoreName(storeName).getList();
+  const result: CdInfo[] = source.filterByStoreName(storeName).getList();
   const actual = result.length;
 
   Logger.info(`検索ストア名：${storeName}`);
@@ -46,14 +46,17 @@ Deno.test("ストア名検索テスト：ヒットあり（パッケージ版）
   assertEquals(notContainTargetStoreCount, 0);
 });
 
-Deno.test("ストア名検索テスト：ヒットあり（ダウンロード版）", () => {
+Deno.test("ストア名検索テスト：ヒットあり（ダウンロード版）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+  const cdInfoAll: CdInfo[] = source.getList();
+  const maxCdCount: number = cdInfoAll.length;
+
   const storeName = "Spotify";
   const exceptedMin = 1;
   const exceptedMax = maxCdCount;
   const regexpStoreName = RegExp(`.*${storeName}.*`);
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByStoreName(storeName).getList();
+  const result: CdInfo[] = source.filterByStoreName(storeName).getList();
   const actual = result.length;
 
   Logger.info(`検索ストア名：${storeName}`);
@@ -81,12 +84,13 @@ Deno.test("ストア名検索テスト：ヒットあり（ダウンロード版
   assertEquals(notContainTargetStoreCount, 0);
 });
 
-Deno.test("ストア名検索テスト：ヒットなし（パッケージ版）", () => {
+Deno.test("ストア名検索テスト：ヒットなし（パッケージ版）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const storeName = "ABCDEFG";
   const expectedCount = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByStoreName(storeName).getList();
+  const result: CdInfo[] = source.filterByStoreName(storeName).getList();
 
   const actualCount = result.length;
 
@@ -96,12 +100,13 @@ Deno.test("ストア名検索テスト：ヒットなし（パッケージ版）
   assertEquals(actualCount, expectedCount);
 });
 
-Deno.test("ストア名検索テスト：ヒットなし（ダウンロード版）", () => {
+Deno.test("ストア名検索テスト：ヒットなし（ダウンロード版）", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const storeName = "ABCDEFG";
   const expectedCount = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByStoreName(storeName).getList();
+  const result: CdInfo[] = source.filterByStoreName(storeName).getList();
 
   const actualCount = result.length;
 

--- a/src/tests/model/title_test.ts
+++ b/src/tests/model/title_test.ts
@@ -1,19 +1,19 @@
-import dataJsonConvertor from "@/functions/data_json_convertor.ts";
+import { getCdInfoListFromGithub } from "@/functions/data_json_convertor.ts";
 import { Logger } from "@/logger.ts";
 import { CdInfo } from "@/model/cd_info.ts";
 import { CdInfoList } from "@/model/cd_info_list.ts";
 import { assertEquals, assertMatch } from "@std/assert";
 
-Deno.test("CDタイトル検索テスト：1件だけヒット", () => {
+Deno.test("CDタイトル検索テスト：1件だけヒット", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const title = "ヒカリのdestination";
   const expectedCount = 1;
   const expectedTitle = RegExp(`.*${title}.*`);
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByTitle(title).getList();
-
-  const actualCount = result.length;
-  const actualTitle = result[0].title;
+  const filteringResult: CdInfo[] = source.filterByTitle(title).getList();
+  const actualCount = filteringResult.length;
+  const actualTitle = filteringResult[0].title;
 
   Logger.info(`検索CDタイトル：${title}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
@@ -25,21 +25,21 @@ Deno.test("CDタイトル検索テスト：1件だけヒット", () => {
   assertMatch(actualTitle, expectedTitle);
 });
 
-Deno.test("CDタイトル検索テスト：複数件数ヒット", () => {
+Deno.test("CDタイトル検索テスト：複数件数ヒット", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const title = "PANOR@MA WING";
   const expectedCount = 8;
   const regexpTitle = RegExp(`.*${title}.*`);
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByTitle(title).getList();
-
-  const actualCount = result.length;
+  const filteringResult: CdInfo[] = source.filterByTitle(title).getList();
+  const actualCount = filteringResult.length;
 
   Logger.info(`検索CDタイトル：${title}`);
   Logger.info(`ヒット件数：${actualCount} / 期待値：${expectedCount}`);
 
   let isContainNotMatchTitle = false;
-  result.forEach((cdInfo) => {
+  filteringResult.forEach((cdInfo) => {
     Logger.info(
       `CDタイトル名：${cdInfo.title}`,
     );
@@ -51,16 +51,17 @@ Deno.test("CDタイトル検索テスト：複数件数ヒット", () => {
   assertEquals(actualCount, expectedCount);
 });
 
-Deno.test("CDタイトル検索テスト：ヒットなし", () => {
+Deno.test("CDタイトル検索テスト：ヒットなし", async () => {
+  const source: CdInfoList = await getCdInfoListFromGithub();
+
   const title = "ABCD";
   const expected = 0;
 
-  const cdInfoList: CdInfoList = dataJsonConvertor();
-  const result: CdInfo[] = cdInfoList.filterByTitle(title).getList();
-  const actual = result.length;
+  const filteringResult: CdInfo[] = source.filterByTitle(title).getList();
+  const actual = filteringResult.length;
 
   Logger.info(`検索CDタイトル：${title}`);
   Logger.info(`ヒット件数：${actual} / 期待値：${expected}`);
 
-  assertEquals(result.length, 0);
+  assertEquals(filteringResult.length, 0);
 });

--- a/src/tests/resources/sort/artist_asc_test_expected.json
+++ b/src/tests/resources/sort/artist_asc_test_expected.json
@@ -1,0 +1,247 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ニューアルバム",
+      "recordNumbers": [
+        "LACA-25133"
+      ],
+      "releaseDate": "2024-11-20",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/08/LACA-25133-1.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "THE IDOLM@STER SHINY COLORS"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 04",
+      "recordNumbers": [
+        "LACM-24364"
+      ],
+      "releaseDate": "2023-07-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/06/LACM-24364.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 02",
+      "recordNumbers": [
+        "LACM-24362"
+      ],
+      "releaseDate": "2023-05-10",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/04/LACM-24362.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "アンティーカ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 時限式狂騒ワンダーランド / LINKs 【アンティーカ盤】",
+      "recordNumbers": [
+        "LACM-24552"
+      ],
+      "releaseDate": "2024-07-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/05/LACM-24552.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "アンティーカ / ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 時限式狂騒ワンダーランド / LINKs 【ストレイライト盤】",
+      "recordNumbers": [
+        "LACM-24553"
+      ],
+      "releaseDate": "2024-07-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/05/LACM-24553.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "アンティーカ / ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 08",
+      "recordNumbers": [
+        "LACM-24368"
+      ],
+      "releaseDate": "2023-11-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/10/LACM-24368.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "コメティック"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ハナムケのハナタバ / 青空 【コメティック盤】",
+      "recordNumbers": [
+        "LACM-24525"
+      ],
+      "releaseDate": "2024-04-03",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/01/LACM-24525.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ハナムケのハナタバ / 青空 【ノクチル盤】",
+      "recordNumbers": [
+        "LACM-24526"
+      ],
+      "releaseDate": "2024-04-03",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/01/LACM-24526.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Heads or Tails / グッバイ 【コメティック盤】",
+      "recordNumbers": [
+        "LACM-24628"
+      ],
+      "releaseDate": "2024-11-27",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/09/LACM-24628.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Heads or Tails / グッバイ 【ノクチル盤】",
+      "recordNumbers": [
+        "LACM-24629"
+      ],
+      "releaseDate": "2024-11-27",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/09/LACM-24629.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 07",
+      "recordNumbers": [
+        "LACM-24367"
+      ],
+      "releaseDate": "2023-10-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/09/LACM-24367.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism After Run / mellow mellow 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24609"
+      ],
+      "releaseDate": "2024-09-25",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/07/LACM-24609.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism After Run / mellow mellow 【アルストロメリア盤】",
+      "recordNumbers": [
+        "LACM-24610"
+      ],
+      "releaseDate": "2024-09-25",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/07/LACM-24610.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 星の声",
+      "recordNumbers": [
+        "LACM-24437"
+      ],
+      "releaseDate": "2023-10-18",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/07/LACM-24437.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シャイニーカラーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 05",
+      "recordNumbers": [
+        "LACM-24365"
+      ],
+      "releaseDate": "2023-08-09",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/07/LACM-24365.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 06",
+      "recordNumbers": [
+        "LACM-24366"
+      ],
+      "releaseDate": "2023-09-13",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/08/LACM-24366.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 03",
+      "recordNumbers": [
+        "LACM-24363"
+      ],
+      "releaseDate": "2023-06-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24363.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "放課後クライマックスガールズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 裸足じゃイラレナイ / 明日もBeautiful Day【放課後クライマックスガールズ盤】",
+      "recordNumbers": [
+        "LACM-24475"
+      ],
+      "releaseDate": "2024-01-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/11/LACM-24475.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "放課後クライマックスガールズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 裸足じゃイラレナイ / 明日もBeautiful Day【アルストロメリア盤】",
+      "recordNumbers": [
+        "LACM-24476"
+      ],
+      "releaseDate": "2024-01-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/11/LACM-24476.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "放課後クライマックスガールズ / アルストロメリア"
+    }
+  ]
+}

--- a/src/tests/resources/sort/artist_desc_test_expected.json
+++ b/src/tests/resources/sort/artist_desc_test_expected.json
@@ -1,0 +1,247 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 裸足じゃイラレナイ / 明日もBeautiful Day【放課後クライマックスガールズ盤】",
+      "recordNumbers": [
+        "LACM-24475"
+      ],
+      "releaseDate": "2024-01-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/11/LACM-24475.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "放課後クライマックスガールズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 裸足じゃイラレナイ / 明日もBeautiful Day【アルストロメリア盤】",
+      "recordNumbers": [
+        "LACM-24476"
+      ],
+      "releaseDate": "2024-01-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/11/LACM-24476.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "放課後クライマックスガールズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 03",
+      "recordNumbers": [
+        "LACM-24363"
+      ],
+      "releaseDate": "2023-06-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24363.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "放課後クライマックスガールズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 06",
+      "recordNumbers": [
+        "LACM-24366"
+      ],
+      "releaseDate": "2023-09-13",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/08/LACM-24366.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 05",
+      "recordNumbers": [
+        "LACM-24365"
+      ],
+      "releaseDate": "2023-08-09",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/07/LACM-24365.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 星の声",
+      "recordNumbers": [
+        "LACM-24437"
+      ],
+      "releaseDate": "2023-10-18",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/07/LACM-24437.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シャイニーカラーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism After Run / mellow mellow 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24609"
+      ],
+      "releaseDate": "2024-09-25",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/07/LACM-24609.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism After Run / mellow mellow 【アルストロメリア盤】",
+      "recordNumbers": [
+        "LACM-24610"
+      ],
+      "releaseDate": "2024-09-25",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/07/LACM-24610.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 07",
+      "recordNumbers": [
+        "LACM-24367"
+      ],
+      "releaseDate": "2023-10-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/09/LACM-24367.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ハナムケのハナタバ / 青空 【コメティック盤】",
+      "recordNumbers": [
+        "LACM-24525"
+      ],
+      "releaseDate": "2024-04-03",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/01/LACM-24525.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ハナムケのハナタバ / 青空 【ノクチル盤】",
+      "recordNumbers": [
+        "LACM-24526"
+      ],
+      "releaseDate": "2024-04-03",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/01/LACM-24526.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Heads or Tails / グッバイ 【コメティック盤】",
+      "recordNumbers": [
+        "LACM-24628"
+      ],
+      "releaseDate": "2024-11-27",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/09/LACM-24628.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Heads or Tails / グッバイ 【ノクチル盤】",
+      "recordNumbers": [
+        "LACM-24629"
+      ],
+      "releaseDate": "2024-11-27",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/09/LACM-24629.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 08",
+      "recordNumbers": [
+        "LACM-24368"
+      ],
+      "releaseDate": "2023-11-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/10/LACM-24368.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "コメティック"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 時限式狂騒ワンダーランド / LINKs 【アンティーカ盤】",
+      "recordNumbers": [
+        "LACM-24552"
+      ],
+      "releaseDate": "2024-07-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/05/LACM-24552.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "アンティーカ / ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 時限式狂騒ワンダーランド / LINKs 【ストレイライト盤】",
+      "recordNumbers": [
+        "LACM-24553"
+      ],
+      "releaseDate": "2024-07-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/05/LACM-24553.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "アンティーカ / ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 02",
+      "recordNumbers": [
+        "LACM-24362"
+      ],
+      "releaseDate": "2023-05-10",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/04/LACM-24362.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "アンティーカ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 04",
+      "recordNumbers": [
+        "LACM-24364"
+      ],
+      "releaseDate": "2023-07-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/06/LACM-24364.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ニューアルバム",
+      "recordNumbers": [
+        "LACA-25133"
+      ],
+      "releaseDate": "2024-11-20",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/08/LACA-25133-1.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "THE IDOLM@STER SHINY COLORS"
+    }
+  ]
+}

--- a/src/tests/resources/sort/artist_test_source.json
+++ b/src/tests/resources/sort/artist_test_source.json
@@ -1,0 +1,247 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 星の声",
+      "recordNumbers": [
+        "LACM-24437"
+      ],
+      "releaseDate": "2023-10-18",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/07/LACM-24437.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シャイニーカラーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 裸足じゃイラレナイ / 明日もBeautiful Day【放課後クライマックスガールズ盤】",
+      "recordNumbers": [
+        "LACM-24475"
+      ],
+      "releaseDate": "2024-01-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/11/LACM-24475.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "放課後クライマックスガールズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 裸足じゃイラレナイ / 明日もBeautiful Day【アルストロメリア盤】",
+      "recordNumbers": [
+        "LACM-24476"
+      ],
+      "releaseDate": "2024-01-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/11/LACM-24476.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "放課後クライマックスガールズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ハナムケのハナタバ / 青空 【コメティック盤】",
+      "recordNumbers": [
+        "LACM-24525"
+      ],
+      "releaseDate": "2024-04-03",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/01/LACM-24525.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ハナムケのハナタバ / 青空 【ノクチル盤】",
+      "recordNumbers": [
+        "LACM-24526"
+      ],
+      "releaseDate": "2024-04-03",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/01/LACM-24526.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 時限式狂騒ワンダーランド / LINKs 【アンティーカ盤】",
+      "recordNumbers": [
+        "LACM-24552"
+      ],
+      "releaseDate": "2024-07-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/05/LACM-24552.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "アンティーカ / ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism 時限式狂騒ワンダーランド / LINKs 【ストレイライト盤】",
+      "recordNumbers": [
+        "LACM-24553"
+      ],
+      "releaseDate": "2024-07-24",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/05/LACM-24553.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "アンティーカ / ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism After Run / mellow mellow 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24609"
+      ],
+      "releaseDate": "2024-09-25",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/07/LACM-24609.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism After Run / mellow mellow 【アルストロメリア盤】",
+      "recordNumbers": [
+        "LACM-24610"
+      ],
+      "releaseDate": "2024-09-25",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/07/LACM-24610.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism ニューアルバム",
+      "recordNumbers": [
+        "LACA-25133"
+      ],
+      "releaseDate": "2024-11-20",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/08/LACA-25133-1.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "THE IDOLM@STER SHINY COLORS"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Heads or Tails / グッバイ 【コメティック盤】",
+      "recordNumbers": [
+        "LACM-24628"
+      ],
+      "releaseDate": "2024-11-27",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/09/LACM-24628.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Heads or Tails / グッバイ 【ノクチル盤】",
+      "recordNumbers": [
+        "LACM-24629"
+      ],
+      "releaseDate": "2024-11-27",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/09/LACM-24629.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "コメティック / ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 02",
+      "recordNumbers": [
+        "LACM-24362"
+      ],
+      "releaseDate": "2023-05-10",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/04/LACM-24362.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "アンティーカ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 03",
+      "recordNumbers": [
+        "LACM-24363"
+      ],
+      "releaseDate": "2023-06-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24363.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "放課後クライマックスガールズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 04",
+      "recordNumbers": [
+        "LACM-24364"
+      ],
+      "releaseDate": "2023-07-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/06/LACM-24364.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "アルストロメリア"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 05",
+      "recordNumbers": [
+        "LACM-24365"
+      ],
+      "releaseDate": "2023-08-09",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/07/LACM-24365.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "ストレイライト"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 06",
+      "recordNumbers": [
+        "LACM-24366"
+      ],
+      "releaseDate": "2023-09-13",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/08/LACM-24366.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "ノクチル"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 07",
+      "recordNumbers": [
+        "LACM-24367"
+      ],
+      "releaseDate": "2023-10-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/09/LACM-24367.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 08",
+      "recordNumbers": [
+        "LACM-24368"
+      ],
+      "releaseDate": "2023-11-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/10/LACM-24368.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "コメティック"
+    }
+  ]
+}

--- a/src/tests/resources/sort/recordNumbers_asc_test_expected.json
+++ b/src/tests/resources/sort/recordNumbers_asc_test_expected.json
@@ -1,0 +1,141 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS WING COLLECTION -A side-",
+      "recordNumbers": [
+        "LACA-9946",
+        "LACA-9947"
+      ],
+      "releaseDate": "2023-01-18",
+      "cdInfoPageUrl": "https://shinycolors.lantis.jp/releaseinfo/laca-9946_7/",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/10/LACA-9946_7.jpg",
+      "limited": false,
+      "series": "WING COLLECTION",
+      "artist": "シャイニーカラーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS SOLO COLLECTION -5thLIVE If I_wings. part1-",
+      "recordNumbers": [
+        "LACZ-10141",
+        "LACZ-10142"
+      ],
+      "releaseDate": "2023-03-18",
+      "cdInfoPageUrl": "https://shinycolors.lantis.jp/releaseinfo/lacz-10141_2/",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/03/LACZ-10141_2.jpg",
+      "limited": true,
+      "series": "SOLO COLLECTION",
+      "artist": "シャイニーカラーズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/recordNumbers_desc_test_expected.json
+++ b/src/tests/resources/sort/recordNumbers_desc_test_expected.json
@@ -1,0 +1,141 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS SOLO COLLECTION -5thLIVE If I_wings. part1-",
+      "recordNumbers": [
+        "LACZ-10141",
+        "LACZ-10142"
+      ],
+      "releaseDate": "2023-03-18",
+      "cdInfoPageUrl": "https://shinycolors.lantis.jp/releaseinfo/lacz-10141_2/",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/03/LACZ-10141_2.jpg",
+      "limited": true,
+      "series": "SOLO COLLECTION",
+      "artist": "シャイニーカラーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS WING COLLECTION -A side-",
+      "recordNumbers": [
+        "LACA-9946",
+        "LACA-9947"
+      ],
+      "releaseDate": "2023-01-18",
+      "cdInfoPageUrl": "https://shinycolors.lantis.jp/releaseinfo/laca-9946_7/",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/10/LACA-9946_7.jpg",
+      "limited": false,
+      "series": "WING COLLECTION",
+      "artist": "シャイニーカラーズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/recordNumbers_test_source.json
+++ b/src/tests/resources/sort/recordNumbers_test_source.json
@@ -1,0 +1,141 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS WING COLLECTION -A side-",
+      "recordNumbers": [
+        "LACA-9946",
+        "LACA-9947"
+      ],
+      "releaseDate": "2023-01-18",
+      "cdInfoPageUrl": "https://shinycolors.lantis.jp/releaseinfo/laca-9946_7/",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/10/LACA-9946_7.jpg",
+      "limited": false,
+      "series": "WING COLLECTION",
+      "artist": "シャイニーカラーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS SOLO COLLECTION -5thLIVE If I_wings. part1-",
+      "recordNumbers": [
+        "LACZ-10141",
+        "LACZ-10142"
+      ],
+      "releaseDate": "2023-03-18",
+      "cdInfoPageUrl": "https://shinycolors.lantis.jp/releaseinfo/lacz-10141_2/",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2023/03/LACZ-10141_2.jpg",
+      "limited": true,
+      "series": "SOLO COLLECTION",
+      "artist": "シャイニーカラーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/releaseDate_asc_test_expected.json
+++ b/src/tests/resources/sort/releaseDate_asc_test_expected.json
@@ -1,0 +1,104 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/releaseDate_desc_test_expected.json
+++ b/src/tests/resources/sort/releaseDate_desc_test_expected.json
@@ -1,0 +1,104 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/releaseDate_test_source.json
+++ b/src/tests/resources/sort/releaseDate_test_source.json
@@ -1,0 +1,104 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/title_asc_test_expected.json
+++ b/src/tests/resources/sort/title_asc_test_expected.json
@@ -1,0 +1,115 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/title_desc_test_expected.json
+++ b/src/tests/resources/sort/title_desc_test_expected.json
@@ -1,0 +1,115 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    }
+  ]
+}

--- a/src/tests/resources/sort/title_test_source.json
+++ b/src/tests/resources/sort/title_test_source.json
@@ -1,0 +1,115 @@
+{
+  "createdAt": 1,
+  "info": [
+    {
+      "title": "THE IDOLM@STER SHINY COLORS BRILLI@NT WING 02 ヒカリのdestination",
+      "recordNumbers": [
+        "LACM-14782"
+      ],
+      "releaseDate": "2018-07-04",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14782.jpg",
+      "limited": false,
+      "series": "BRILLI@NT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS FR@GMENT WING 02",
+      "recordNumbers": [
+        "LACM-14862"
+      ],
+      "releaseDate": "2019-05-08",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14862.jpg",
+      "limited": false,
+      "series": "FR@GMENT WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS GR@DATE WING 02",
+      "recordNumbers": [
+        "LACM-14983"
+      ],
+      "releaseDate": "2020-10-14",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-14983.jpg",
+      "limited": false,
+      "series": "GR@DATE WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【イルミネーションスターズ盤】",
+      "recordNumbers": [
+        "LACM-24529"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24529.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Synthe-Side 03",
+      "recordNumbers": [
+        "LACM-24246"
+      ],
+      "releaseDate": "2022-04-23",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/01/LACM-24246.jpg",
+      "limited": false,
+      "series": "Synthe-Side",
+      "artist": "イルミネーションスターズ×アルストロメリア×シーズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS PANOR@MA WING 02",
+      "recordNumbers": [
+        "LACM-24252"
+      ],
+      "releaseDate": "2022-05-11",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24252.jpg",
+      "limited": false,
+      "series": "PANOR@MA WING",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS “CANVAS” 01",
+      "recordNumbers": [
+        "LACM-24361"
+      ],
+      "releaseDate": "2023-04-12",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2022/12/LACM-24361.jpg",
+      "limited": false,
+      "series": "CANVAS",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS ECHOES 01",
+      "recordNumbers": [
+        "LACM-24541"
+      ],
+      "releaseDate": "2025-01-22",
+      "jacketUrl": "/images/nowprinting.jpg",
+      "limited": false,
+      "series": "ECHOES",
+      "artist": "イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS Song for Prism Happier / 枕木の歌 【シーズ盤】",
+      "recordNumbers": [
+        "LACM-24528"
+      ],
+      "releaseDate": "2024-05-22",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2024/03/LACM-24528.jpg",
+      "limited": false,
+      "series": "Song for Prism",
+      "artist": "シーズ / イルミネーションスターズ"
+    },
+    {
+      "title": "THE IDOLM@STER SHINY COLORS L@YERED WING 02",
+      "recordNumbers": [
+        "LACM-24112"
+      ],
+      "releaseDate": "2021-05-19",
+      "jacketUrl": "https://shinycolors.lantis.jp/X9pa5jNY/wp-content/uploads/2021/12/LACM-24112.jpg",
+      "limited": false,
+      "series": "L@YERED WING",
+      "artist": "イルミネーションスターズ"
+    }
+  ]
+}


### PR DESCRIPTION
### 変更内容
- build(deno.jsonc): タスクを新規追加、一部変更を行った (e8a66f5504d8973d9fefa861593d8ca1a330d47a)
- feat: CD情報取得時の取得先をカスタムできるようにした (49370e40ce2303bfcc053ec28a367b8147bc1afe)
- feat: CD情報のソート機能を追加した (1d47eaef72e07bcf2fb779b930bae00b68cf6d5b)